### PR TITLE
Satış düzenleme hatası düzeltmesi

### DIFF
--- a/src/main/java/com/koop/app/service/SatisService.java
+++ b/src/main/java/com/koop/app/service/SatisService.java
@@ -117,6 +117,7 @@ public class SatisService {
 
         Map<Long, SatisStokHareketleri> stokHareketMap = stokHareketleriLists
             .stream()
+            .filter(satisStokHareketleri -> satisStokHareketleri.getId() != null)
             .collect(Collectors.toMap(SatisStokHareketleri::getId, satisStokHareketleri -> satisStokHareketleri));
         for (SatisStokHareketleri stokHareketleri : satisOncekiHali.getStokHareketleriLists()) {
             if (!stokHareketMap.containsKey(stokHareketleri.getId())) {


### PR DESCRIPTION
Satış düzenlenirken bir kerede birden fazla ürün eklenince null idli satış stok hareketleri onlardan map yaratmaya çalışırken çarpışıyor. Zaten map sadece düzenlemede çıkarılacak ürünler için kullanılacağı için null idli stok hareketlerine ihtiyacı yok, filtreleyerek çıkarıyoruz.

Closes #8

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/mertmr/pirot/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](ttps://github.com/mertmr/pirot/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
